### PR TITLE
Add Expression#value

### DIFF
--- a/lib/opt/expression.rb
+++ b/lib/opt/expression.rb
@@ -57,6 +57,13 @@ module Opt
       end
     end
 
+    def value
+      values = parts.map(&:value)
+      return nil if values.any?(&:nil?)
+
+      values.sum
+    end
+
     def vars
       @vars ||= @parts.flat_map(&:vars)
     end

--- a/lib/opt/product.rb
+++ b/lib/opt/product.rb
@@ -11,6 +11,12 @@ module Opt
       "#{inspect_part(@left)} * #{inspect_part(@right)}"
     end
 
+    def value
+      return nil if left.value.nil? || right.value.nil?
+
+      left.value * right.value
+    end
+
     def vars
       @vars ||= (@left.vars + @right.vars).uniq
     end

--- a/test/expression_test.rb
+++ b/test/expression_test.rb
@@ -51,4 +51,22 @@ class ExpressionTest < Minitest::Test
     end
     assert_equal "Nonlinear", error.message
   end
+
+  def test_value
+    expression = 2 * @x1 + 3 * @x2 * @x2
+    @x1.value = 1
+    @x2.value = 2
+    assert_equal 14, expression.value
+  end
+
+  def test_nil_value
+    expression = 2 * @x1 + 3 * @x2 * @x2
+    assert_equal nil, expression.value
+
+    @x1.value = 1
+    assert_equal nil, expression.value
+
+    @x2.value = 1
+    assert_equal 5, expression.value
+  end
 end


### PR DESCRIPTION
This new method is useful to test and visualize the final result of the optimization process.
With this one can easily check the final values of the constraints:
```rb
x1 = Opt::Variable.new(0.., "x1")
x2 = Opt::Variable.new(0.., "x2")

prob = Opt::Problem.new
my_value = 2 * x1 + 2 * x2
prob.add(my_value >= 7)
prob.minimize(8 * x1 + 10 * x2)
prob.solve

puts my_value.value
```

This avoid having to re-write the expression once the problem is solved like:
```rb
my_value_final = 2 * x1.value + 2 * x2.value
```

Note that no changes to `Constant` and `Variable` were needed as they both already expose `#value` public method