### PR TITLE
Fix supported available solvers throwing error

### DIFF
--- a/lib/opt.rb
+++ b/lib/opt.rb
@@ -34,8 +34,10 @@ module Opt
     solvers[key] = cls
   end
 
-  def self.available_solvers
-    solvers.select { |k, v| v.available? }.map(&:first)
+  def self.available_solvers(&filter)
+    available_solvers = solvers.select { |_, v| v.available? }
+    available_solvers = available_solvers.select(&filter) unless filter.nil?
+    available_solvers.map(&:first)
   end
 end
 

--- a/lib/opt/problem.rb
+++ b/lib/opt/problem.rb
@@ -40,7 +40,7 @@ module Opt
 
       raise Error, "No solvers found" if Opt.available_solvers.empty?
 
-      solver ||= (Opt.default_solvers[type] || Opt.available_solvers.find { |s| s.supports_type?(type) })
+      solver ||= (Opt.default_solvers[type] || Opt.available_solvers { |_, s| s.supports_type?(type) }.first)
       raise Error, "No solvers found for #{type}" unless solver
 
       # TODO better error message

--- a/test/opt_test.rb
+++ b/test/opt_test.rb
@@ -4,4 +4,8 @@ class OptTest < Minitest::Test
   def test_available_solvers
     assert_includes Opt.available_solvers, Opt.default_solvers[:lp]
   end
+
+  def test_available_solvers_with_filtering
+    assert_includes Opt.available_solvers { |_, solver| solver.supports_type?(:qp) }, :highs
+  end
 end


### PR DESCRIPTION
This line was throwing an error when no `default_solvers` were specified because the method `#supports_type` was being called on a `:symbol`:
https://github.com/ankane/opt/blob/5c373d8e202194067a454d8fb573904cf468f9de/lib/opt/problem.rb#L43

This is because `available_solvers` returns an array of symbols.

This PR adds a `filter` block argument to `available_solvers` to fix that